### PR TITLE
Add Launchy save_and_open_page to forbidden list

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -25,7 +25,8 @@ FORBIDDEN = [
   /console\.log/,    # ''
   /binding\.pry/,        # pry debugging code
   /binding\.remote_pry/, # ''
-  /save_and_open_page/   # Launchy debugging code
+  /save_and_open_page/,  # Launchy debugging code
+  /debugger/             # Ruby debugging code
 ]
 
 # Warning signs that someone is committing a private key


### PR DESCRIPTION
[Launchy](https://github.com/copiousfreetime/launchy) is a gem that, among other things, provides a 'save_and_open_page' method. It opens a page in the browser that renders the page as Capybara saw it when the method was called. For obvious reasons, we don't want these method calls in committed test code.
